### PR TITLE
Remove the x-model-provider header

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -113,8 +113,7 @@ OpenResponses is designed to work with existing OpenAI SDKs:
     
     client = OpenAI(
         base_url="http://localhost:8080/v1",
-        api_key="your-api-key",
-        default_headers={'x-model-provider': 'openai'}
+        api_key="your-api-key"
     )
     
     response = client.chat.completions.create(
@@ -133,8 +132,7 @@ OpenResponses is designed to work with existing OpenAI SDKs:
     
     const openai = new OpenAI({
       baseURL: 'http://localhost:8080/v1',
-      apiKey: 'your-api-key',
-      defaultHeaders: {'x-model-provider': 'openai'}
+      apiKey: 'your-api-key'
     });
     
     async function main() {

--- a/development.mdx
+++ b/development.mdx
@@ -117,9 +117,8 @@ The main configuration files are:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "input": [
         {
             "role": "user",

--- a/faq.mdx
+++ b/faq.mdx
@@ -69,11 +69,10 @@ import os
 
 openai_client = OpenAI(
     base_url="http://localhost:8080/v1", 
-    api_key=os.getenv("OPENAI_API_KEY"), 
-    default_headers={'x-model-provider': 'openai'}
+    api_key=os.getenv("OPENAI_API_KEY")
 )
 
-response = openai_client.responses.create(
+response = openai_client.chat.completions.create(
     model="gpt-4o-mini",
     input="Tell me a joke"
 )
@@ -88,8 +87,7 @@ import os
 
 client = AsyncOpenAI(
     base_url="http://localhost:8080/v1", 
-    api_key=os.getenv("OPENAI_API_KEY"), 
-    default_headers={'x-model-provider': 'openai'}
+    api_key=os.getenv("OPENAI_API_KEY")
 )
 
 agent = Agent(

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -50,11 +50,10 @@ import os
 
 openai_client = OpenAI(
     base_url="http://localhost:8080/v1", 
-    api_key=os.getenv("OPENAI_API_KEY"), 
-    default_headers={'x-model-provider': 'openai'}
+    api_key=os.getenv("OPENAI_API_KEY")
 )
 
-response = openai_client.responses.create(
+response = openai_client.chat.completions.create(
     model="gpt-4o-mini",
     input="Tell me a joke"
 )
@@ -68,8 +67,7 @@ import os
 
 client = AsyncOpenAI(
     base_url="http://localhost:8080/v1", 
-    api_key=os.getenv("OPENAI_API_KEY"), 
-    default_headers={'x-model-provider': 'openai'}
+    api_key=os.getenv("OPENAI_API_KEY")
 )
 
 agent = Agent(
@@ -84,9 +82,8 @@ agent = Agent(
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "stream": false,
     "input": [
         {

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -106,9 +106,8 @@ For a complete list of all supported model providers with detailed curl examples
     curl --location 'http://localhost:8080/v1/responses' \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer OPENAI_API_KEY' \
-    --header 'x-model-provider: openai' \
     --data '{
-        "model": "gpt-4o",
+        "model": "openai@gpt-4o",
         "stream": false,
         "input": [
             {
@@ -127,7 +126,7 @@ For a complete list of all supported model providers with detailed curl examples
     --header 'Authorization: Bearer ANTHROPIC_API_KEY' \
     --header 'x-model-provider: claude' \
     --data '{
-        "model": "claude-3-5-sonnet-20241022",
+        "model": "claude@claude-3-5-sonnet-20241022",
         "stream": false,
         "input": [
             {
@@ -230,7 +229,7 @@ Stop previously running docker-compose (if any) before running this command.
     --header 'Authorization: Bearer OPENAI_API_KEY' \
     --header 'x-model-provider: openai' \
     --data '{
-        "model": "gpt-4o",
+        "model": "openai@gpt-4o",
         "stream": false,
         "tools": [
             {
@@ -253,7 +252,7 @@ Stop previously running docker-compose (if any) before running this command.
     --header 'Authorization: Bearer ANTHROPIC_API_KEY' \
     --header 'x-model-provider: claude' \
     --data '{
-        "model": "claude-3-7-sonnet-20250219",
+        "model": "claude@claude-3-7-sonnet-20250219",
         "stream": false,
         "tools": [
            {"type": "think"}
@@ -422,7 +421,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer OPENAI_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "store": true,
     "input": [
         {
@@ -493,7 +492,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer OPENAI_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "store": true,
     "previous_response_id": "chatcmpl-BLB88IDIyyHjupNiAqOZQvAfT2T3K",
     "input": [
@@ -656,7 +655,7 @@ docker-compose --profile qdrant-mongodb up
     --header 'Authorization: Bearer OPENAI_API_KEY' \
     --header 'x-model-provider: openai' \
     --data '{
-        "model": "gpt-4o",
+        "model": "openai@gpt-4o",
         "tools": [{
           "type": "file_search",
           "vector_store_ids": ["YOUR_VECTOR_STORE_ID"],
@@ -674,7 +673,7 @@ docker-compose --profile qdrant-mongodb up
     --header 'Authorization: Bearer ANTHROPIC_API_KEY' \
     --header 'x-model-provider: claude' \
     --data '{
-        "model": "claude-3-5-sonnet-20241022",
+        "model": "claude@claude-3-5-sonnet-20241022",
         "tools": [{
           "type": "file_search",
           "vector_store_ids": ["YOUR_VECTOR_STORE_ID"],

--- a/rag/overview.mdx
+++ b/rag/overview.mdx
@@ -377,9 +377,8 @@ You can integrate RAG with OpenAI models by using the `file_search` tool:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "store": true,
     "tools": [{
       "type": "file_search",

--- a/rag/search-api.mdx
+++ b/rag/search-api.mdx
@@ -514,9 +514,8 @@ The `file_search` tool provides an alternative way to search vector stores throu
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "file_search",
       "vector_store_ids": ["vs_abc123"],
@@ -597,7 +596,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "agentic_search",
       "vector_store_ids": ["vs_abc123"],

--- a/tools/agentic-search.mdx
+++ b/tools/agentic-search.mdx
@@ -67,9 +67,8 @@ Basic configuration requires a query parameter and vector store IDs:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "agentic_search",
@@ -87,7 +86,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "agentic_search",
@@ -400,7 +399,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "agentic_search",
       "vector_store_ids": ["vs_architecture_docs", "vs_engineering_blogs"],

--- a/tools/file-search.mdx
+++ b/tools/file-search.mdx
@@ -40,9 +40,8 @@ Basic configuration requires a query parameter:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "file_search",
@@ -60,7 +59,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "file_search",
@@ -201,7 +200,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "file_search",
       "vector_store_ids": ["vs_security_docs"],
@@ -242,7 +241,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "file_search",
       "vector_store_ids": ["vs_technical_docs", "vs_code_examples", "vs_architecture"],
@@ -301,7 +300,7 @@ curl --location 'http://localhost:8080/v1/responses' \
   --header 'Authorization: Bearer $OPENAI_API_KEY' \
   --header 'x-model-provider: openai' \
   --data '{
-      "model": "gpt-4o",
+      "model": "openai@gpt-4o",
       "tools": [{
         "type": "file_search",
         "vector_store_ids": ["vs_engineering_docs"],
@@ -340,7 +339,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "file_search",
       "vector_store_ids": ["vs_technical_docs"],

--- a/tools/overview.mdx
+++ b/tools/overview.mdx
@@ -129,9 +129,8 @@ Start with minimal configuration for each tool:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "think"
@@ -148,7 +147,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "file_search",
@@ -166,7 +165,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "agentic_search",

--- a/tools/think.mdx
+++ b/tools/think.mdx
@@ -168,9 +168,8 @@ Explicitly record assumptions being made:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "think"
@@ -221,7 +220,7 @@ curl --location 'http://localhost:8080/v1/responses' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
 --header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "think"


### PR DESCRIPTION
Removed the x-model-provider header from API calls and updated the model field in curl requests to use the provider@model format.