### PR TITLE
Remove the x-model-provider header

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -24,12 +24,6 @@ All API requests require authentication using an API key. The API key should be 
 Authorization: Bearer YOUR_API_KEY
 ```
 
-For model-specific requests, you need to specify the model provider using the `x-model-provider` header:
-
-```
-x-model-provider: openai
-```
-
 Supported model providers include:
 - `openai` - OpenAI models (GPT-4o, GPT-3.5 Turbo, etc.)
 - `claude` - Anthropic models (Claude 3.5 Sonnet, Claude 3 Opus, etc.)
@@ -113,8 +107,7 @@ OpenResponses is designed to work with existing OpenAI SDKs:
     
     client = OpenAI(
         base_url="http://localhost:8080/v1",
-        api_key="your-api-key",
-        default_headers={'x-model-provider': 'openai'}
+        api_key="your-api-key"
     )
     
     response = client.chat.completions.create(
@@ -133,8 +126,7 @@ OpenResponses is designed to work with existing OpenAI SDKs:
     
     const openai = new OpenAI({
       baseURL: 'http://localhost:8080/v1',
-      apiKey: 'your-api-key',
-      defaultHeaders: {'x-model-provider': 'openai'}
+      apiKey: 'your-api-key'
     });
     
     async function main() {

--- a/development.mdx
+++ b/development.mdx
@@ -117,9 +117,8 @@ The main configuration files are:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "input": [
         {
             "role": "user",

--- a/faq.mdx
+++ b/faq.mdx
@@ -69,8 +69,7 @@ import os
 
 openai_client = OpenAI(
     base_url="http://localhost:8080/v1", 
-    api_key=os.getenv("OPENAI_API_KEY"), 
-    default_headers={'x-model-provider': 'openai'}
+    api_key=os.getenv("OPENAI_API_KEY")
 )
 
 response = openai_client.responses.create(
@@ -88,8 +87,7 @@ import os
 
 client = AsyncOpenAI(
     base_url="http://localhost:8080/v1", 
-    api_key=os.getenv("OPENAI_API_KEY"), 
-    default_headers={'x-model-provider': 'openai'}
+    api_key=os.getenv("OPENAI_API_KEY")
 )
 
 agent = Agent(

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -50,8 +50,7 @@ import os
 
 openai_client = OpenAI(
     base_url="http://localhost:8080/v1", 
-    api_key=os.getenv("OPENAI_API_KEY"), 
-    default_headers={'x-model-provider': 'openai'}
+    api_key=os.getenv("OPENAI_API_KEY")
 )
 
 response = openai_client.responses.create(
@@ -68,8 +67,7 @@ import os
 
 client = AsyncOpenAI(
     base_url="http://localhost:8080/v1", 
-    api_key=os.getenv("OPENAI_API_KEY"), 
-    default_headers={'x-model-provider': 'openai'}
+    api_key=os.getenv("OPENAI_API_KEY")
 )
 
 agent = Agent(
@@ -84,9 +82,8 @@ agent = Agent(
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "stream": false,
     "input": [
         {

--- a/openresponses/compatibility.mdx
+++ b/openresponses/compatibility.mdx
@@ -362,7 +362,7 @@ curl -X POST https://api.openai.com/v1/responses \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer YOUR_API_KEY" \
 -d '{
-  "model": "gpt-4o",
+  "model": "openai@gpt-4o",
   "input": "Hello, world!"
 }'
 ```
@@ -379,7 +379,7 @@ curl -X POST https://api.openai.com/v1/responses \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer YOUR_API_KEY" \
 -d '{
-  "model": "gpt-4o",
+  "model": "openai@gpt-4o",
   "instructions": "Answer concisely.",
   "input": "Explain AI."
 }'
@@ -394,7 +394,7 @@ curl -X POST https://api.openai.com/v1/responses \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer YOUR_API_KEY" \
 -d '{
-  "model": "gpt-4o",
+  "model": "openai@gpt-4o",
   "temperature": 0.5,
   "input": "Suggest a creative startup idea."
 }'
@@ -412,7 +412,7 @@ curl -X POST https://api.openai.com/v1/responses \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer YOUR_API_KEY" \
 -d '{
-    "model": "gpt-4o-2024-08-06",
+    "model": "openai@gpt-4o-2024-08-06",
     "input": [
       {
         "role": "system",
@@ -465,7 +465,7 @@ curl -X POST https://api.openai.com/v1/responses \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer YOUR_API_KEY" \
 -d '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "input": [
       {
         "role": "user",
@@ -493,7 +493,7 @@ curl -X POST https://api.openai.com/v1/responses \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer YOUR_API_KEY" \
 -d '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "input": "What is the weather like in Boston today?",
     "tools": [
       {
@@ -532,7 +532,7 @@ curl -N -X POST https://api.openai.com/v1/responses \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer YOUR_API_KEY" \
 -d '{
-  "model": "gpt-4o",
+  "model": "openai@gpt-4o",
   "input": "Stream your response.",
   "stream": true
 }'
@@ -548,7 +548,7 @@ curl -X POST https://api.openai.com/v1/responses \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer YOUR_API_KEY" \
 -d '{
-  "model": "gpt-4o",
+  "model": "openai@gpt-4o",
   "input": "Metadata example.",
   "store": true,
   "metadata": {

--- a/openresponses/storage.mdx
+++ b/openresponses/storage.mdx
@@ -42,7 +42,7 @@ Use the `store` parameter in your API requests to control whether responses are 
 
 ```json
 {
-  "model": "gpt-4o",
+  "model": "openai@gpt-4o",
   "input": "Tell me a bedtime story about a unicorn.",
   "store": true  // Set to true to store the conversation
 }
@@ -107,9 +107,8 @@ docker-compose --profile mongodb up -d
 curl http://localhost:8080/v1/responses \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $OPENAI_API_KEY" \
-  -H "x-model-provider: openai" \
   -d '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "input": [
       {"role": "user", "content": "Tell me a three sentence bedtime story about a unicorn."}
     ],
@@ -173,9 +172,8 @@ To reference a previously stored conversation, use the response ID:
 curl http://localhost:8080/v1/responses \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $OPENAI_API_KEY" \
-  -H "x-model-provider: openai" \
   -d '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "previous_response_id": "chatcmpl-BLB88IDIyyHjupNiAqOZQvAfT2T3K",
     "input": [
       {"role": "user", "content": "Make the story longer."}

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -106,9 +106,8 @@ For a complete list of all supported model providers with detailed curl examples
     curl --location 'http://localhost:8080/v1/responses' \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer OPENAI_API_KEY' \
-    --header 'x-model-provider: openai' \
     --data '{
-        "model": "gpt-4o",
+        "model": "openai@gpt-4o",
         "stream": false,
         "input": [
             {
@@ -125,9 +124,8 @@ For a complete list of all supported model providers with detailed curl examples
     curl --location 'http://localhost:8080/v1/responses' \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer ANTHROPIC_API_KEY' \
-    --header 'x-model-provider: claude' \
     --data '{
-        "model": "claude-3-5-sonnet-20241022",
+        "model": "claude@claude@claude-3-5-sonnet-20241022",
         "stream": false,
         "input": [
             {
@@ -145,7 +143,7 @@ For a complete list of all supported model providers with detailed curl examples
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer GROQ_API_KEY' \
     --data '{
-        "model": "llama-3.2-3b-preview",
+        "model": "groq@llama-3.2-3b-preview",
         "stream": true,
         "input": [
             {
@@ -207,7 +205,7 @@ Stop previously running docker-compose (if any) before running this command.
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer GROQ_API_KEY' \
     --data '{
-        "model": "qwen-2.5-32b",
+        "model": "groq@qwen-2.5-32b",
         "stream": false,
         "tools": [
             {
@@ -228,9 +226,8 @@ Stop previously running docker-compose (if any) before running this command.
     curl --location 'http://localhost:8080/v1/responses' \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer OPENAI_API_KEY' \
-    --header 'x-model-provider: openai' \
     --data '{
-        "model": "gpt-4o",
+        "model": "openai@gpt-4o",
         "stream": false,
         "tools": [
             {
@@ -251,9 +248,8 @@ Stop previously running docker-compose (if any) before running this command.
     curl --location 'http://localhost:8080/v1/responses' \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer ANTHROPIC_API_KEY' \
-    --header 'x-model-provider: claude' \
     --data '{
-        "model": "claude-3-7-sonnet-20250219",
+        "model": "claude@claude-3-7-sonnet-20250219",
         "stream": false,
         "tools": [
            {"type": "think"}
@@ -420,9 +416,8 @@ To test that responses are being stored, make an API call with the `store` param
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "store": true,
     "input": [
         {
@@ -491,9 +486,8 @@ To continue a stored conversation, use the `previous_response_id` from your earl
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "store": true,
     "previous_response_id": "chatcmpl-BLB88IDIyyHjupNiAqOZQvAfT2T3K",
     "input": [
@@ -619,7 +613,7 @@ docker-compose --profile qdrant-mongodb up
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer YOUR_LLM_API_KEY' \
     --data '{
-      "model": "gpt-4o",
+      "model": "openai@gpt-4o",
       "tools": [{
         "type": "file_search",
         "vector_store_ids": ["YOUR_VECTOR_STORE_ID"],
@@ -654,9 +648,8 @@ docker-compose --profile qdrant-mongodb up
     curl --location 'http://localhost:8080/v1/responses' \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer OPENAI_API_KEY' \
-    --header 'x-model-provider: openai' \
     --data '{
-        "model": "gpt-4o",
+        "model": "openai@gpt-4o",
         "tools": [{
           "type": "file_search",
           "vector_store_ids": ["YOUR_VECTOR_STORE_ID"],
@@ -672,9 +665,8 @@ docker-compose --profile qdrant-mongodb up
     curl --location 'http://localhost:8080/v1/responses' \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer ANTHROPIC_API_KEY' \
-    --header 'x-model-provider: claude' \
     --data '{
-        "model": "claude-3-5-sonnet-20241022",
+        "model": "claude@claude-3-5-sonnet-20241022",
         "tools": [{
           "type": "file_search",
           "vector_store_ids": ["YOUR_VECTOR_STORE_ID"],
@@ -691,7 +683,7 @@ docker-compose --profile qdrant-mongodb up
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer GROQ_API_KEY' \
     --data '{
-        "model": "llama-3.2-3b-preview",
+        "model": "groq@llama-3.2-3b-preview",
         "tools": [{
           "type": "file_search",
           "vector_store_ids": ["YOUR_VECTOR_STORE_ID"],

--- a/rag/overview.mdx
+++ b/rag/overview.mdx
@@ -377,9 +377,8 @@ You can integrate RAG with OpenAI models by using the `file_search` tool:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "store": true,
     "tools": [{
       "type": "file_search",

--- a/rag/search-api.mdx
+++ b/rag/search-api.mdx
@@ -514,9 +514,8 @@ The `file_search` tool provides an alternative way to search vector stores throu
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "file_search",
       "vector_store_ids": ["vs_abc123"],
@@ -595,9 +594,8 @@ The `agentic_search` tool offers an AI-guided approach to search that handles co
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "agentic_search",
       "vector_store_ids": ["vs_abc123"],

--- a/tools/agentic-search.mdx
+++ b/tools/agentic-search.mdx
@@ -67,9 +67,8 @@ Basic configuration requires a query parameter and vector store IDs:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "agentic_search",
@@ -85,9 +84,8 @@ curl --location 'http://localhost:8080/v1/responses' \
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "agentic_search",
@@ -398,9 +396,8 @@ The following parameters enable dynamic adjustment of the underlying model's par
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "agentic_search",
       "vector_store_ids": ["vs_architecture_docs", "vs_engineering_blogs"],

--- a/tools/file-search.mdx
+++ b/tools/file-search.mdx
@@ -40,9 +40,8 @@ Basic configuration requires a query parameter:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "file_search",
@@ -58,9 +57,8 @@ curl --location 'http://localhost:8080/v1/responses' \
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "file_search",
@@ -199,9 +197,8 @@ The `filters` parameter allows you to narrow search results based on document me
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "file_search",
       "vector_store_ids": ["vs_security_docs"],
@@ -240,9 +237,8 @@ Searching across multiple vector stores allows you to find information across di
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "file_search",
       "vector_store_ids": ["vs_technical_docs", "vs_code_examples", "vs_architecture"],
@@ -299,9 +295,8 @@ curl --location 'http://localhost:8080/v1/responses' \
   curl --location 'http://localhost:8080/v1/responses' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer $OPENAI_API_KEY' \
-  --header 'x-model-provider: openai' \
   --data '{
-      "model": "gpt-4o",
+      "model": "openai@gpt-4o",
       "tools": [{
         "type": "file_search",
         "vector_store_ids": ["vs_engineering_docs"],
@@ -338,9 +333,8 @@ curl --location 'http://localhost:8080/v1/responses' \
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [{
       "type": "file_search",
       "vector_store_ids": ["vs_technical_docs"],

--- a/tools/overview.mdx
+++ b/tools/overview.mdx
@@ -129,9 +129,8 @@ Start with minimal configuration for each tool:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "think"
@@ -146,9 +145,8 @@ curl --location 'http://localhost:8080/v1/responses' \
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "file_search",
@@ -164,9 +162,8 @@ curl --location 'http://localhost:8080/v1/responses' \
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $YOUR_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "agentic_search",

--- a/tools/think.mdx
+++ b/tools/think.mdx
@@ -168,9 +168,8 @@ Explicitly record assumptions being made:
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "think"
@@ -219,9 +218,8 @@ print(response)
 curl --location 'http://localhost:8080/v1/responses' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $OPENAI_API_KEY' \
---header 'x-model-provider: openai' \
 --data '{
-    "model": "gpt-4o",
+    "model": "openai@gpt-4o",
     "tools": [
       {
         "type": "think"


### PR DESCRIPTION
Removed the x-model-provider header from API calls and updated the model field in curl requests to use the provider@model format.